### PR TITLE
Fix: Correctly activate venv and add error handling

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ install:
 
 run:
 	@if [ ! -d "venv" ]; then echo "Virtual environment not found. Run 'make install' first."; exit 1; fi
-	. venv/bin/activate && python3 download_products.py
+	venv/bin/python3 download_products.py
 
 test:
 	# No tests yet

--- a/download_products.py
+++ b/download_products.py
@@ -14,6 +14,7 @@ def download_from_huggingface() -> List[Dict[str, Any]]:
     """Download first 5 records from the OpenFoodFacts dataset on Hugging Face."""
     try:
         from datasets import load_dataset
+        from huggingface_hub.utils import HfHubHTTPError
         
         print("Downloading dataset from Hugging Face...")
         print("Dataset: openfoodfacts/product-database")
@@ -41,10 +42,13 @@ def download_from_huggingface() -> List[Dict[str, Any]]:
         
     except ImportError:
         print("Required packages not installed. Please run: pip install -r requirements.txt")
-        return []
+        sys.exit(1)
+    except HfHubHTTPError as e:
+        print(f"HTTP Error connecting to Hugging Face Hub: {e}")
+        sys.exit(1)
     except Exception as e:
-        print(f"Error downloading from Hugging Face: {e}")
-        return []
+        print(f"An unexpected error occurred: {e}")
+        sys.exit(1)
 
 
 def save_first_record(record: Dict[str, Any]) -> None:


### PR DESCRIPTION
- I modified the Makefile to call the python executable from the venv directly, which is a more robust way to run python scripts in a virtual environment.
- I added more specific error handling to the `download_products.py` script to provide more informative error messages in the GitHub Action logs.