### PR TITLE
Map all required product fields

### DIFF
--- a/.github/workflows/download-food-records.yml
+++ b/.github/workflows/download-food-records.yml
@@ -40,12 +40,12 @@ jobs:
         make run
         echo "✅ Food records download completed!"
         
-    - name: Upload first record as artifact
+    - name: Upload products as artifact
       uses: actions/upload-artifact@v4
       if: always()
       with:
-        name: first-food-record
-        path: first_record.json
+        name: products
+        path: products.json
         retention-days: 30
         
     - name: Upload run summary
@@ -56,5 +56,5 @@ jobs:
         echo "✅ **Status**: Completed successfully" >> $GITHUB_STEP_SUMMARY
         echo "📊 **Records**: 5 food product records downloaded and displayed" >> $GITHUB_STEP_SUMMARY
         echo "🔗 **Source**: OpenFoodFacts dataset via Hugging Face" >> $GITHUB_STEP_SUMMARY
-        echo "📁 **Artifact**: First record saved as 'first-food-record' artifact" >> $GITHUB_STEP_SUMMARY
+        echo "📁 **Artifact**: Products saved as 'products' artifact" >> $GITHUB_STEP_SUMMARY
         echo "⏰ **Timestamp**: $(date -u)" >> $GITHUB_STEP_SUMMARY

--- a/download_products.py
+++ b/download_products.py
@@ -33,10 +33,21 @@ def download_from_huggingface():
  
             product = {
                 '_id': record.get('code'),
-                'lang':record.get('lang'),
+                'lang': record.get('lang'),
                 'product_name': record.get('product_name'),
-
-                # TODO: Map other fields
+                'brands': record.get('brands'),
+                'food_groups_tags': record.get('food_groups_tags'),
+                'product_quantity_unit': record.get('product_quantity_unit'),
+                'product_quantity': record.get('product_quantity'),
+                'quantity': record.get('quantity'),
+                'categories_tags': record.get('categories_tags'),
+                'categories': [c.strip() for c in record.get('categories', '').split(',') if record.get('categories')] if record.get('categories') else [],
+                'labels_tags': record.get('labels_tags'),
+                'labels': [l.strip() for l in record.get('labels', '').split(',') if record.get('labels')] if record.get('labels') else [],
+                'popularity_key': record.get('popularity_key'),
+                'popularity_tags': record.get('popularity_tags'),
+                'nutriscore_grade': record.get('nutriscore_grade'),
+                'nutriscore_score': record.get('nutriscore_score'),
             }
             products.append(product)
 
@@ -54,10 +65,8 @@ def download_from_huggingface():
         
         print(f"Successfully downloaded {i} records")
 
-        # Save the first record to a file
-        # if records:
-        #     save_first_record(records[0])
-        
+        save_products_to_json(products)
+
     except ImportError:
         print("Required packages not installed. Please run: pip install -r requirements.txt")
         return []
@@ -66,15 +75,15 @@ def download_from_huggingface():
         return []
 
 
-# def save_first_record(record: Dict[str, Any]) -> None:
-#     """Save the first record to a JSON file."""
-#     filename = "first_record.json"
-#     try:
-#         with open(filename, 'w', encoding='utf-8') as f:
-#             json.dump(record, f, indent=2, ensure_ascii=False)
-#         print(f"First record saved to '{filename}'")
-#     except Exception as e:
-#         print(f"Error saving first record: {e}")
+def save_products_to_json(products: List[Dict[str, Any]]) -> None:
+    """Save the products to a JSON file."""
+    filename = "products.json"
+    try:
+        with open(filename, 'w', encoding='utf-8') as f:
+            json.dump(products, f, indent=2, ensure_ascii=False)
+        print(f"Products saved to '{filename}'")
+    except Exception as e:
+        print(f"Error saving products to JSON: {e}")
 
 
 # def print_records(records: List[Dict[str, Any]]) -> None:

--- a/products.json
+++ b/products.json
@@ -1,0 +1,225 @@
+[
+  {
+    "_id": "0000101209159",
+    "lang": "fr",
+    "product_name": [
+      {
+        "lang": "main",
+        "text": "Véritable pâte à tartiner noisettes chocolat noir"
+      },
+      {
+        "lang": "fr",
+        "text": "Véritable pâte à tartiner noisettes chocolat noir"
+      }
+    ],
+    "brands": "Bovetti",
+    "food_groups_tags": [
+      "en:sugary-snacks",
+      "en:sweets"
+    ],
+    "product_quantity_unit": "g",
+    "product_quantity": "350",
+    "quantity": "350 g",
+    "categories_tags": [
+      "en:breakfasts",
+      "en:spreads",
+      "en:sweet-spreads",
+      "fr:pates-a-tartiner",
+      "en:hazelnut-spreads",
+      "en:chocolate-spreads",
+      "en:cocoa-and-hazelnuts-spreads"
+    ],
+    "categories": [
+      "Petit-déjeuners",
+      "Produits à tartiner",
+      "Produits à tartiner sucrés",
+      "Pâtes à tartiner",
+      "Pâtes à tartiner aux noisettes",
+      "Pâtes à tartiner au chocolat",
+      "Pâtes à tartiner aux noisettes et au cacao"
+    ],
+    "labels_tags": [
+      "en:no-gluten",
+      "en:no-palm-oil"
+    ],
+    "labels": [
+      "Sans gluten",
+      "Sans huile de palme"
+    ],
+    "popularity_key": 1,
+    "popularity_tags": [
+      "top-75-percent-scans-2024",
+      "top-80-percent-scans-2024",
+      "top-85-percent-scans-2024",
+      "top-90-percent-scans-2024",
+      "top-1000-sg-scans-2024",
+      "top-5000-sg-scans-2024",
+      "top-10000-sg-scans-2024",
+      "top-50000-sg-scans-2024",
+      "top-100000-sg-scans-2024",
+      "top-country-sg-scans-2024"
+    ],
+    "nutriscore_grade": "e",
+    "nutriscore_score": 25
+  },
+  {
+    "_id": "0000105000011",
+    "lang": "en",
+    "product_name": [
+      {
+        "lang": "main",
+        "text": "Chamomile Herbal Tea"
+      },
+      {
+        "lang": "en",
+        "text": "Chamomile Herbal Tea"
+      }
+    ],
+    "brands": "Lagg's",
+    "food_groups_tags": [],
+    "product_quantity_unit": "g",
+    "product_quantity": "1.0",
+    "quantity": "1 g",
+    "categories_tags": [
+      "en:null"
+    ],
+    "categories": [
+      "null"
+    ],
+    "labels_tags": null,
+    "labels": [],
+    "popularity_key": 1,
+    "popularity_tags": [
+      "bottom-25-percent-scans-2020",
+      "bottom-20-percent-scans-2020",
+      "top-85-percent-scans-2020",
+      "top-90-percent-scans-2020",
+      "top-50000-us-scans-2020",
+      "top-100000-us-scans-2020",
+      "top-country-us-scans-2020"
+    ],
+    "nutriscore_grade": "unknown",
+    "nutriscore_score": null
+  },
+  {
+    "_id": "0000105000042",
+    "lang": "en",
+    "product_name": [
+      {
+        "lang": "main",
+        "text": "Lagg's, herbal tea, peppermint"
+      },
+      {
+        "lang": "en",
+        "text": "Lagg's, herbal tea, peppermint"
+      }
+    ],
+    "brands": "Lagg's",
+    "food_groups_tags": [
+      "en:beverages",
+      "en:unsweetened-beverages"
+    ],
+    "product_quantity_unit": null,
+    "product_quantity": null,
+    "quantity": null,
+    "categories_tags": [
+      "en:plant-based-foods-and-beverages",
+      "en:beverages",
+      "en:hot-beverages",
+      "en:plant-based-beverages",
+      "en:teas",
+      "en:tea-bags"
+    ],
+    "categories": [
+      "Plant-based foods and beverages",
+      "Beverages",
+      "Hot beverages",
+      "Plant-based beverages",
+      "Teas",
+      "Tea bags"
+    ],
+    "labels_tags": null,
+    "labels": [],
+    "popularity_key": 0,
+    "popularity_tags": null,
+    "nutriscore_grade": "unknown",
+    "nutriscore_score": null
+  },
+  {
+    "_id": "0000105000059",
+    "lang": "en",
+    "product_name": [
+      {
+        "lang": "main",
+        "text": "Linden Flowers Tea"
+      },
+      {
+        "lang": "en",
+        "text": "Linden Flowers Tea"
+      }
+    ],
+    "brands": "Lagg's",
+    "food_groups_tags": [
+      "en:beverages",
+      "en:unsweetened-beverages"
+    ],
+    "product_quantity_unit": "g",
+    "product_quantity": "1.5",
+    "quantity": "1.5 g",
+    "categories_tags": [
+      "en:beverages-and-beverages-preparations",
+      "en:plant-based-foods-and-beverages",
+      "en:beverages",
+      "en:hot-beverages",
+      "en:plant-based-beverages",
+      "en:beverage-preparations",
+      "en:teas",
+      "en:tea-leaves",
+      "en:tea-bags",
+      "en:null"
+    ],
+    "categories": [
+      "Beverages and beverages preparations",
+      "Plant-based foods and beverages",
+      "Beverages",
+      "Hot beverages",
+      "Plant-based beverages",
+      "Teas",
+      "Null",
+      "en:tea-bags"
+    ],
+    "labels_tags": null,
+    "labels": [],
+    "popularity_key": 0,
+    "popularity_tags": null,
+    "nutriscore_grade": "unknown",
+    "nutriscore_score": null
+  },
+  {
+    "_id": "0000105000073",
+    "lang": "en",
+    "product_name": [
+      {
+        "lang": "main",
+        "text": "Herbal Tea, Hibiscus"
+      },
+      {
+        "lang": "en",
+        "text": "Herbal Tea, Hibiscus"
+      }
+    ],
+    "brands": "Lagg's",
+    "food_groups_tags": [],
+    "product_quantity_unit": null,
+    "product_quantity": null,
+    "quantity": null,
+    "categories_tags": null,
+    "categories": [],
+    "labels_tags": null,
+    "labels": [],
+    "popularity_key": 0,
+    "popularity_tags": null,
+    "nutriscore_grade": "unknown",
+    "nutriscore_score": null
+  }
+]


### PR DESCRIPTION
This commit updates the `download_products.py` script to map all the required fields from the OpenFoodFacts dataset.

The following fields are now mapped:
- brands
- food_groups_tags
- product_quantity_unit
- product_quantity
- quantity
- categories_tags
- categories (comma-separated string to array)
- labels_tags
- labels (comma-separated string to array)
- popularity_key
- popularity_tags
- nutriscore_grade
- nutriscore_score

The script now saves the mapped products to `products.json`, and the GitHub workflow has been updated to upload this file as an artifact.